### PR TITLE
chore: remove optional github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,3 @@ jobs:
       contents: write    
     steps:
       - uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
removing the optional dependabot github token