### PR TITLE
chore: replace set-output and save-state

### DIFF
--- a/.github/workflows/cypress-github-multiple-runners-example
+++ b/.github/workflows/cypress-github-multiple-runners-example
@@ -18,11 +18,11 @@ jobs:
       - id: set-test-chunks
         name: Set Chunks
         # Get all the spec files from the directory, group them to be at most 'CHUNK_SIZE' at a time and transform them to json
-        run: echo "::set-output name=test-chunks::$(find cypress/e2e -type f -name "*.ts" | xargs -n$CHUNK_SIZE | tr ' ' ',' | jq -R . | jq -s -cM .)"
+        run: echo "test-chunks=$(find cypress/e2e -type f -name "*.ts" | xargs -n$CHUNK_SIZE | tr ' ' ',' | jq -R . | jq -s -cM .)" >> $GITHUB_OUTPUT
       - id: set-test-chunk-ids
         name: Set Chunk IDs
         # Get the number of elements from the above array as an array of indexes
-        run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"
+        run: echo "test-chunk-ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
         env:
           CHUNKS: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
  


### PR DESCRIPTION
<h4>GitHub Actions: Deprecating save-state and set-output commands.</h4>GitHub actions using the mentioned commands will start to fail from 1st of June of 2023.<br>This PR is part of a bulk update to prevent so, please review and test it before merging.<br><a href="https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/">Reference</a>